### PR TITLE
Use $DISPLAY env var instead of static 0

### DIFF
--- a/compose/live-view.yml
+++ b/compose/live-view.yml
@@ -12,7 +12,7 @@ services:
       liveView: "true"
       fullscreenView: "true"
       showVideoDebugStats: "true"
-      DISPLAY: "unix:0"
+      DISPLAY: "unix${DISPLAY}"
 
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix


### PR DESCRIPTION
The $DISPLAY is not always 0, so it is better to use the environment variable rather than static 0. This is an issue that was causing the video to fail on a test machine.